### PR TITLE
Enable compiler optimizations to improve inference speed

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -5,6 +5,11 @@
 # Sets the minimum CMake version required for this project.
 cmake_minimum_required(VERSION 3.22.1)
 
+# Enable compiler optimization with -Ofast
+# The flag -fno-finite-math-only is required to disable some optimization that rely on the
+# assumption that floating point math can't result in infinite
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Ofast -fno-finite-math-only")
+
 # Check if the target architecture is arm64-v8a
 if(${CMAKE_ANDROID_ARCH_ABI} STREQUAL "arm64-v8a")
         # Set the C flags for arm64-v8a

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.22.1)
 # Check if the target architecture is arm64-v8a
 if(${CMAKE_ANDROID_ARCH_ABI} STREQUAL "arm64-v8a")
         # Set the C flags for arm64-v8a
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8.4a+dotprod")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8.4a+dotprod+i8mm")
 endif()
 
 # include_directories(Vulkan-Hpp)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.32.0"
-androidGradlePlugin = "8.6.1"
+androidGradlePlugin = "8.7.1"
 androidx-activity-compose = "1.8.2"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.2.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR introduces a couple of simple compiler flags that can greatly improve inference speed

As described in section 5.1.2 of the paper Jie Xiao, Qianyi Huang, Xu Chen, Chen Tian. _Large Language Model Performance Benchmarking on Mobile Platforms: A Thorough Evaluation_, [arXiv:2410.03613](https://arxiv.org/abs/2410.03613), the flag `i8mm` has been added to the architecture description for arm64-v8a processors. This flag supposedly enables the generation of machine instructions optimised for int8 math.

The flag `-Ofast` has been specified in CMakeLists.txt to enable compiler optimisations for any architecture. This change requires the flag `-fno-finite-math-only` to be specified so that we disable all the optimisations based on the assumption that floating point math cannot result in infinite.

With those changes, I was able to observe great performance improvements on my device (Motorola Edge 20) when using Llama3.2-1B-Q4K_M:

- 1568% improvement for **prompt eval time**, from 2.27 to 37.9 tokens/s
- 636% improvement for **inference speed**, from 1.30 to 9.58 tokens/s
- 86% **energy usage** reduction, from 364 to 50 μAh per generated token