### PR TITLE
Fix send button enabling

### DIFF
--- a/app/src/main/java/com/druk/lmplayground/conversation/ConversationFragment.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/ConversationFragment.kt
@@ -61,6 +61,7 @@ class ConversationFragment : Fragment() {
             val isGenerating by viewModel.isGenerating.observeAsState()
             val progress by viewModel.modelLoadingProgress.observeAsState(0f)
             val modelInfo by viewModel.loadedModel.observeAsState()
+            val isModelReady by viewModel.isModelReady.observeAsState(false)
             val models by viewModel.models.observeAsState(emptyList())
 
             PlaygroundTheme {
@@ -155,7 +156,7 @@ class ConversationFragment : Fragment() {
                             modifier = Modifier
                                 .navigationBarsPadding()
                                 .imePadding(),
-                            status = if (modelInfo == null)
+                            status = if (modelInfo == null || !isModelReady)
                                 UserInputStatus.NOT_LOADED
                             else if (isGenerating == true)
                                 UserInputStatus.GENERATING


### PR DESCRIPTION
## Summary
- disable user input until the selected LLM model is ready
- add LiveData `isModelReady` to track model loading status

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684970029184832a94249a69bb3bfca3