### PR TITLE
Add markdown support for model answers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.util)
     implementation(libs.androidx.compose.ui.viewbinding)
     implementation(libs.androidx.compose.ui.googlefonts)
+    implementation(libs.compose.richtext.ui)
+    implementation(libs.compose.richtext.commonmark)
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 

--- a/app/src/main/java/com/druk/lmplayground/conversation/MessageChatBubble.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/MessageChatBubble.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import com.halilibo.richtext.commonmark.Markdown
+import com.halilibo.richtext.ui.material3.RichText
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -35,16 +37,22 @@ fun ChatItemBubble(
 
     Column {
         Surface {
-            val styledMessage = messageFormatter(
-                text = message.content,
-                primary = isUserMe
-            )
-
             SelectionContainer {
-                Text(
-                    text = styledMessage,
-                    style = MaterialTheme.typography.bodyLarge.copy(color = LocalContentColor.current)
-                )
+                if (isUserMe) {
+                    val styledMessage = messageFormatter(
+                        text = message.content,
+                        primary = isUserMe
+                    )
+
+                    Text(
+                        text = styledMessage,
+                        style = MaterialTheme.typography.bodyLarge.copy(color = LocalContentColor.current)
+                    )
+                } else {
+                    RichText {
+                        Markdown(message.content)
+                    }
+                }
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ androidx-window = "1.3.0-alpha01"
 androidxHiltNavigationCompose = "1.1.0"
 androix-test-uiautomator = "2.2.0"
 coil = "2.4.0"
+composeRichText = "1.0.0-alpha02"
 # @keep
 compileSdk = "35"
 compose-compiler = "1.5.4"
@@ -130,6 +131,8 @@ okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 rometools-modules = { module = "com.rometools:rome-modules", version.ref = "rome" }
 rometools-rome = { module = "com.rometools:rome", version.ref = "rome" }
+compose-richtext-ui = { module = "com.halilibo.compose-richtext:richtext-ui", version.ref = "composeRichText" }
+compose-richtext-commonmark = { module = "com.halilibo.compose-richtext:richtext-commonmark", version.ref = "composeRichText" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
## Summary
- support Markdown rendering for model answers
- integrate compose-richtext library
- parse model answers with Markdown

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684970b1ce80832a90c64ab3e9b4bf33