### PR TITLE
Add generation parameter panel and JNI support

### DIFF
--- a/app/src/main/cpp/LlamaCpp.h
+++ b/app/src/main/cpp/LlamaCpp.h
@@ -16,7 +16,11 @@ public:
 
     ~LlamaGenerationSession();
 
-    void init(llama_model *model);
+    void init(llama_model *model,
+              int32_t n_ctx,
+              float   temperature,
+              float   top_p,
+              int32_t top_k);
 
     void printReport();
 
@@ -45,7 +49,10 @@ public:
     LlamaModel() = default;
     ~LlamaModel() = default;
 
-    LlamaGenerationSession* createGenerationSession();
+    LlamaGenerationSession* createGenerationSession(int32_t n_ctx,
+                                                    float   temperature,
+                                                    float   top_p,
+                                                    int32_t top_k);
     void loadModel(const std::string &modelPath,
                    int32_t n_gpu_layers,
                    llama_progress_callback progress_callback,

--- a/app/src/main/cpp/LlamaGenerationSession.cpp
+++ b/app/src/main/cpp/LlamaGenerationSession.cpp
@@ -89,7 +89,11 @@ LlamaGenerationSession::~LlamaGenerationSession() {
     }
 }
 
-void LlamaGenerationSession::init(llama_model *model) {
+void LlamaGenerationSession::init(llama_model *model,
+                                  int32_t n_ctx,
+                                  float   temperature,
+                                  float   top_p,
+                                  int32_t top_k) {
 
     vocab = llama_model_get_vocab(model);
 
@@ -98,8 +102,8 @@ void LlamaGenerationSession::init(llama_model *model) {
 
     // initialize the context
     llama_context_params ctx_params = llama_context_default_params();
-    ctx_params.n_ctx = 2048;
-    ctx_params.n_batch = 2048;
+    ctx_params.n_ctx = n_ctx;
+    ctx_params.n_batch = n_ctx;
     ctx_params.n_threads       = n_threads;
     ctx_params.n_threads_batch = n_threads;
 
@@ -114,9 +118,9 @@ void LlamaGenerationSession::init(llama_model *model) {
 
     // initialize the sampler
     smpl = llama_sampler_chain_init(smplParams);
-    llama_sampler_chain_add(smpl, llama_sampler_init_greedy());
-    llama_sampler_chain_add(smpl, llama_sampler_init_min_p(0.05f, 1));
-    llama_sampler_chain_add(smpl, llama_sampler_init_temp(0.8f));
+    llama_sampler_chain_add(smpl, llama_sampler_init_top_k(top_k));
+    llama_sampler_chain_add(smpl, llama_sampler_init_top_p(top_p, 1));
+    llama_sampler_chain_add(smpl, llama_sampler_init_temp(temperature));
     llama_sampler_chain_add(smpl, llama_sampler_init_dist(LLAMA_DEFAULT_SEED));
 
     messages = new std::vector<llama_chat_message>();

--- a/app/src/main/cpp/LlamaModel.cpp
+++ b/app/src/main/cpp/LlamaModel.cpp
@@ -46,9 +46,12 @@ void LlamaModel::loadModel(const std::string &modelPath,
     }
 }
 
-LlamaGenerationSession* LlamaModel::createGenerationSession() {
+LlamaGenerationSession* LlamaModel::createGenerationSession(int32_t n_ctx,
+                                                           float   temperature,
+                                                           float   top_p,
+                                                           int32_t top_k) {
     auto *session = new LlamaGenerationSession();
-    session->init(model);
+    session->init(model, n_ctx, temperature, top_p, top_k);
     return session;
 }
 

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -128,7 +128,11 @@ Java_com_druk_llamacpp_LlamaModel_unloadModel(JNIEnv *env, jobject thiz) {
 
 extern "C"
 JNIEXPORT jobject JNICALL
-Java_com_druk_llamacpp_LlamaModel_createSession(JNIEnv *env, jobject thiz) {
+Java_com_druk_llamacpp_LlamaModel_createSession(JNIEnv *env, jobject thiz,
+                                                jint n_ctx,
+                                                jfloat temperature,
+                                                jfloat top_p,
+                                                jint top_k) {
 
     jclass clazz1 = env->GetObjectClass(thiz);
     jfieldID fid1 = env->GetFieldID(clazz1, "nativeHandle", "J");
@@ -138,7 +142,10 @@ Java_com_druk_llamacpp_LlamaModel_createSession(JNIEnv *env, jobject thiz) {
     jmethodID constructor = env->GetMethodID(clazz2, "<init>", "()V");
     jobject obj = env->NewObject(clazz2, constructor);
 
-    LlamaGenerationSession* session = model->createGenerationSession();
+    LlamaGenerationSession* session = model->createGenerationSession(n_ctx,
+                                                                     temperature,
+                                                                     top_p,
+                                                                     top_k);
     jclass clazz3 = env->GetObjectClass(obj);
     jfieldID fid3 = env->GetFieldID(clazz3, "nativeHandle", "J");
     env->SetLongField(obj, fid3, (long)session);

--- a/app/src/main/java/com/druk/llamacpp/LlamaModel.kt
+++ b/app/src/main/java/com/druk/llamacpp/LlamaModel.kt
@@ -19,7 +19,12 @@ class LlamaModel {
      *
      * @return A `LlamaGenerationSession` object for managing text generation.
      */
-    external fun createSession(): LlamaGenerationSession
+    external fun createSession(
+        contextSize: Int,
+        temperature: Float,
+        topP: Float,
+        topK: Int
+    ): LlamaGenerationSession
 
     /**
      * Gets the size of the model in bytes.

--- a/app/src/main/java/com/druk/lmplayground/conversation/ConversationBar.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/ConversationBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material.icons.outlined.Eject
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -45,7 +46,8 @@ fun ConversationBar(
     scrollBehavior: TopAppBarScrollBehavior? = null,
     onSelectModelPressed: () -> Unit = { },
     onUnloadModelPressed: () -> Unit = { },
-    onNavIconPressed: () -> Unit = { }
+    onNavIconPressed: () -> Unit = { },
+    onSettingsPressed: () -> Unit = { }
 ) {
     var functionalityNotAvailablePopupShown by remember { mutableStateOf(false) }
     if (functionalityNotAvailablePopupShown) {
@@ -116,7 +118,15 @@ fun ConversationBar(
         },
         actions = {
             if (modelInfo != null) {
-                // Info icon
+                Icon(
+                    imageVector = Icons.Outlined.Tune,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .clickable(onClick = onSettingsPressed)
+                        .padding(horizontal = 12.dp, vertical = 16.dp)
+                        .height(24.dp),
+                    contentDescription = "Settings"
+                )
                 Icon(
                     imageVector = Icons.Outlined.Info,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -126,9 +136,15 @@ fun ConversationBar(
                         .height(24.dp),
                     contentDescription = stringResource(id = R.string.info)
                 )
-            }
-            else {
-                // Info icon
+            } else {
+                Icon(
+                    imageVector = Icons.Outlined.Tune,
+                    tint = MaterialTheme.colorScheme.outlineVariant,
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp, vertical = 16.dp)
+                        .height(24.dp),
+                    contentDescription = "Settings"
+                )
                 Icon(
                     imageVector = Icons.Outlined.Info,
                     tint = MaterialTheme.colorScheme.outlineVariant,

--- a/app/src/main/java/com/druk/lmplayground/conversation/ConversationFragment.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/ConversationFragment.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.druk.lmplayground.models.SelectModelDialog
+import com.druk.lmplayground.models.GenerationParams
 import com.druk.lmplayground.theme.PlaygroundTheme
 import kotlinx.coroutines.launch
 
@@ -72,7 +73,10 @@ class ConversationFragment : Fragment() {
 
                 val colorScheme = MaterialTheme.colorScheme
                 var modelReport by remember { mutableStateOf<String?>(null) }
+                var showParams by remember { mutableStateOf(false) }
+                val params by viewModel.generationParams.observeAsState(GenerationParams())
 
+                Box {
                 Scaffold(
                     topBar = {
                         ConversationBar(
@@ -86,7 +90,8 @@ class ConversationFragment : Fragment() {
                             },
                             onUnloadModelPressed = {
                                 viewModel.unloadModel()
-                            }
+                            },
+                            onSettingsPressed = { showParams = true }
                         )
                         if (models.isNotEmpty()) {
                             SelectModelDialog(
@@ -179,6 +184,13 @@ class ConversationFragment : Fragment() {
                         )
                     }
                 }
+                ParametersPanel(
+                    visible = showParams,
+                    params = params,
+                    onApply = { viewModel.applyGenerationParams(it) },
+                    onDismiss = { showParams = false },
+                    modifier = Modifier.align(Alignment.TopEnd)
+                )
             }
         }
     }

--- a/app/src/main/java/com/druk/lmplayground/conversation/ConversationViewModel.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/ConversationViewModel.kt
@@ -26,6 +26,7 @@ import com.druk.llamacpp.LlamaProgressCallback
 import com.druk.lmplayground.App
 import com.druk.lmplayground.models.ModelInfo
 import com.druk.lmplayground.models.ModelInfoProvider
+import com.druk.lmplayground.models.GenerationParams
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
@@ -44,6 +45,7 @@ class ConversationViewModel(val app: Application) : AndroidViewModel(app) {
     private val _modelLoadingProgress = MutableLiveData(0f)
     private val _loadedModel = MutableLiveData<ModelInfo?>(null)
     private val _models = MutableLiveData<List<ModelInfo>>(emptyList())
+    private val _generationParams = MutableLiveData(GenerationParams())
     private var downloadModels = TreeMap<Long, ModelInfo>()
     private val downloadManager: DownloadManager by lazy {
         app.getSystemService(DOWNLOAD_SERVICE) as DownloadManager
@@ -53,6 +55,7 @@ class ConversationViewModel(val app: Application) : AndroidViewModel(app) {
     val modelLoadingProgress: LiveData<Float> = _modelLoadingProgress
     val loadedModel: LiveData<ModelInfo?> = _loadedModel
     val models: LiveData<List<ModelInfo>> = _models
+    val generationParams: LiveData<GenerationParams> = _generationParams
 
     val uiState = ConversationUiState(
         initialMessages = emptyList()
@@ -151,7 +154,13 @@ class ConversationViewModel(val app: Application) : AndroidViewModel(app) {
                 )
                 val modelSize = llamaModel.getModelSize()
                 val modelDescription = Formatter.formatFileSize(app, modelSize)
-                val llamaSession = llamaModel.createSession()
+                val params = _generationParams.value ?: GenerationParams()
+                val llamaSession = llamaModel.createSession(
+                    params.contextSize,
+                    params.temperature,
+                    params.topP,
+                    params.topK
+                )
                 this@ConversationViewModel.llamaModel = llamaModel
                 this@ConversationViewModel.llamaSession = llamaSession
                 _modelLoadingProgress.postValue(0f)
@@ -236,6 +245,13 @@ class ConversationViewModel(val app: Application) : AndroidViewModel(app) {
 
     fun resetModelList() {
         _models.postValue(emptyList())
+    }
+
+    fun applyGenerationParams(params: GenerationParams) {
+        _generationParams.postValue(params)
+        val model = _loadedModel.value ?: return
+        unloadModel()
+        loadModel(model)
     }
 
     fun downloadModel(model: ModelInfo) {

--- a/app/src/main/java/com/druk/lmplayground/conversation/ParametersPanel.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/ParametersPanel.kt
@@ -1,0 +1,78 @@
+package com.druk.lmplayground.conversation
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.druk.lmplayground.models.GenerationParams
+
+@Composable
+fun ParametersPanel(
+    visible: Boolean,
+    params: GenerationParams,
+    onApply: (GenerationParams) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = slideInHorizontally(animationSpec = tween(), initialOffsetX = { it }) + fadeIn(),
+        exit = slideOutHorizontally(animationSpec = tween(), targetOffsetX = { it }) + fadeOut(),
+        modifier = modifier
+    ) {
+        Surface(modifier = Modifier
+            .width(280.dp)
+            .fillMaxHeight()
+            .padding(16.dp)
+        ) {
+            val ctx = remember { mutableStateOf(params.contextSize.toString()) }
+            val temp = remember { mutableStateOf(params.temperature.toString()) }
+            val topP = remember { mutableStateOf(params.topP.toString()) }
+            val topK = remember { mutableStateOf(params.topK.toString()) }
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                IconButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
+                    Icon(imageVector = Icons.Outlined.Close, contentDescription = null)
+                }
+                OutlinedTextField(value = ctx.value, onValueChange = { ctx.value = it }, label = { Text("Context size") })
+                OutlinedTextField(value = temp.value, onValueChange = { temp.value = it }, label = { Text("Temperature") })
+                OutlinedTextField(value = topP.value, onValueChange = { topP.value = it }, label = { Text("Top P") })
+                OutlinedTextField(value = topK.value, onValueChange = { topK.value = it }, label = { Text("Top K") })
+                Spacer(modifier = Modifier.weight(1f))
+                Button(onClick = {
+                    onApply(
+                        GenerationParams(
+                            contextSize = ctx.value.toIntOrNull() ?: params.contextSize,
+                            temperature = temp.value.toFloatOrNull() ?: params.temperature,
+                            topP = topP.value.toFloatOrNull() ?: params.topP,
+                            topK = topK.value.toIntOrNull() ?: params.topK
+                        )
+                    )
+                }, modifier = Modifier.align(Alignment.End)) {
+                    Text("Apply")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/druk/lmplayground/models/GenerationParams.kt
+++ b/app/src/main/java/com/druk/lmplayground/models/GenerationParams.kt
@@ -1,0 +1,11 @@
+package com.druk.lmplayground.models
+
+/**
+ * Parameters controlling llama.cpp generation.
+ */
+data class GenerationParams(
+    val contextSize: Int = 2048,
+    val temperature: Float = 0.8f,
+    val topP: Float = 0.95f,
+    val topK: Int = 40
+)


### PR DESCRIPTION
## Summary
- pull llama.cpp submodule for headers
- add `GenerationParams` data class and right-side `ParametersPanel` UI
- allow configuring context size, temperature, topP and topK
- extend `LlamaModel.createSession` to accept these parameters
- update `LlamaGenerationSession` initialization and JNI bridge
- reload model when parameters are applied via the new panel

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684971cb3d74832a9ad67ed00463c8e3