### PR TITLE
Implement message rating buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ google-services.json
 *.hprof
 app/src/main/cpp/clblast
 app/release
+android-commandlinetools.zip
+~/

--- a/app/src/main/java/com/druk/lmplayground/conversation/MessageChatBubble.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/MessageChatBubble.kt
@@ -2,9 +2,14 @@ package com.druk.lmplayground.conversation
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.LocalContentColor
@@ -12,11 +17,21 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.ThumbUp
+import androidx.compose.material.icons.outlined.ThumbDown
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import com.druk.lmplayground.R
 
 private val ChatBubbleShape = RoundedCornerShape(20.dp, 20.dp, 20.dp, 20.dp)
@@ -32,6 +47,8 @@ fun ChatItemBubble(
     } else {
         MaterialTheme.colorScheme.surfaceVariant
     }
+    var showRatingSheet by remember { mutableStateOf(false) }
+    val clipboardManager = LocalClipboardManager.current
 
     Column {
         Surface {
@@ -62,5 +79,37 @@ fun ChatItemBubble(
                 )
             }
         }
+
+        if (!isUserMe) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                IconButton(onClick = {
+                    clipboardManager.setText(AnnotatedString(message.content))
+                }) {
+                    Icon(
+                        imageVector = Icons.Outlined.ContentCopy,
+                        contentDescription = stringResource(id = R.string.copy)
+                    )
+                }
+                IconButton(onClick = { /* upvote - no-op */ }) {
+                    Icon(
+                        imageVector = Icons.Outlined.ThumbUp,
+                        contentDescription = stringResource(id = R.string.upvote)
+                    )
+                }
+                IconButton(onClick = { showRatingSheet = true }) {
+                    Icon(
+                        imageVector = Icons.Outlined.ThumbDown,
+                        contentDescription = stringResource(id = R.string.downvote)
+                    )
+                }
+            }
+        }
+    }
+
+    if (showRatingSheet) {
+        RatingBottomSheet(onDismiss = { showRatingSheet = false })
     }
 }

--- a/app/src/main/java/com/druk/lmplayground/conversation/RatingBottomSheet.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/RatingBottomSheet.kt
@@ -1,0 +1,68 @@
+package com.druk.lmplayground.conversation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.druk.lmplayground.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RatingBottomSheet(onDismiss: () -> Unit) {
+    val sheetState = rememberModalBottomSheetState()
+    val options = remember { mutableStateListOf(false, false, false, false, false) }
+    val labels = listOf(
+        stringResource(id = R.string.offensive_unsafe),
+        stringResource(id = R.string.not_correct),
+        stringResource(id = R.string.didnt_follow_instructions),
+        stringResource(id = R.string.wrong_language),
+        stringResource(id = R.string.other)
+    )
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(id = R.string.rating_question),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.padding(4.dp))
+            labels.forEachIndexed { index, label ->
+                FilterChip(
+                    selected = options[index],
+                    onClick = { options[index] = !options[index] },
+                    label = { Text(text = label) },
+                    leadingIcon = if (options[index]) {
+                        { Icon(Icons.Default.Check, contentDescription = null) }
+                    } else null,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+            }
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+            ) {
+                Text(text = stringResource(id = R.string.send))
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,4 +52,14 @@
     <string name="record_message">Record voice message</string>
     <string name="stop">Stop</string>
 
+    <string name="copy">Copy</string>
+    <string name="upvote">Upvote</string>
+    <string name="downvote">Downvote</string>
+    <string name="rating_question">Why did you choose this rating?</string>
+    <string name="offensive_unsafe">Offensive/Unsafe</string>
+    <string name="not_correct">Not correct</string>
+    <string name="didnt_follow_instructions">Didn\'t follow instructions</string>
+    <string name="wrong_language">Wrong language</string>
+    <string name="other">Other</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- add icons for copying, upvoting and downvoting model messages
- show a rating bottom sheet with checkbox chips
- include new string resources for the UI
- fix rating string quoting
- ignore SDK artifacts in git

## Testing
- `./gradlew assembleDebug` *(fails: Invalid unicode escape in strings)*
- `./gradlew spotlessApply` *(task not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6d579a14832ab8470bee773d4250